### PR TITLE
fix: handler state not passed by reference to mpiHandler

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,8 @@
 
 using namespace drogon;
 
-int main() {
+int main()
+{
   // Initialize the MPI multithreaded environment
   int provided;
   MPI_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &provided);
@@ -28,7 +29,7 @@ int main() {
 
   // Print off a hello world message
   printf("%s: Rest Server with rank %d out of %d processors\n",
-          processor_name, worldRank, worldSize);
+         processor_name, worldRank, worldSize);
 
   int availableLambdas[worldSize];
 
@@ -38,7 +39,7 @@ int main() {
 
   for (int i = 1; i < worldSize; i++)
   {
-    handlerStates[i - 1] = { availableLambdas[i], 0 };
+    handlerStates[i - 1] = {availableLambdas[i], 0};
   }
 
   int requestCounter = 0;
@@ -46,13 +47,13 @@ int main() {
   std::map<int, PendingRequest> pendingRequests;
   std::queue<UnhandledRequest> unhandledRequests;
 
-  #pragma omp parallel sections num_threads(2)
+#pragma omp parallel sections num_threads(2)
   {
-    #pragma omp section
+#pragma omp section
     {
       restServer(worldSize, handlerStates, requestCounter, pendingRequests, unhandledRequests);
     }
-    #pragma omp section
+#pragma omp section
     {
       mpiHandler(worldSize, handlerStates, requestCounter, pendingRequests, unhandledRequests);
     }

--- a/utils/misc.hpp
+++ b/utils/misc.hpp
@@ -2,26 +2,33 @@
 
 #include "globalStructures.hpp"
 
-int getAvailableHandler(std::vector<HandlerState> handlerStates) {
+int getAvailableHandler(std::vector<HandlerState> handlerStates)
+{
   int availableHandler = -1;
 
   int i = 0;
-  while (i < handlerStates.size() && availableHandler == -1) {
-    if (handlerStates[i].lambdasRunning < handlerStates[i].lambdas) {
+  while (i < handlerStates.size() && availableHandler == -1)
+  {
+    if (handlerStates[i].lambdasRunning < handlerStates[i].lambdas)
+    {
       availableHandler = i;
     }
     i++;
   }
-  
+
   return availableHandler + 1;
 }
 
-bool convertToInt(const std::string& str, int *result) {
+bool convertToInt(const std::string &str, int *result)
+{
   size_t pos = 0;
 
-  try {
+  try
+  {
     *result = std::stoi(str, &pos);
-  } catch (const std::exception&) {
+  }
+  catch (const std::exception &)
+  {
     // Conversion failed, return false
     return false;
   }

--- a/utils/mpiUtils.hpp
+++ b/utils/mpiUtils.hpp
@@ -1,8 +1,10 @@
 #include "globalStructures.hpp"
 
-void mpiHandler(int worldSize, std::vector<HandlerState> handlerStates, int &requestCounter, std::map<int, PendingRequest> &pendingRequests, std::queue<UnhandledRequest> &unhandledRequests) {
+void mpiHandler(int worldSize, std::vector<HandlerState> &handlerStates, int &requestCounter, std::map<int, PendingRequest> &pendingRequests, std::queue<UnhandledRequest> &unhandledRequests)
+{
   LOG_INFO << "MPI Handler started";
-  while (true) {
+  while (true)
+  {
     MPI_Status status;
     MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
     LOG_INFO << "MPI Handler received from " << status.MPI_SOURCE << " with tag " << status.MPI_TAG;
@@ -10,13 +12,17 @@ void mpiHandler(int worldSize, std::vector<HandlerState> handlerStates, int &req
     {
       std::unique_lock<std::mutex> lock(stateMutex);
       std::unique_lock<std::mutex> lock2(unhandledRequestsMutex);
-      if (!unhandledRequests.empty()) {
+      if (!unhandledRequests.empty())
+      {
         auto unhandledRequest = unhandledRequests.front();
         unhandledRequests.pop();
-        LOG_INFO << "Request " << unhandledRequest.requestNumber << " has been dequed and will be executed. lambda id: " << unhandledRequest.lambdaId;
+        LOG_INFO << "Request " << unhandledRequest.requestNumber << " has been dequed and will be executed on handler " << status.MPI_SOURCE << ". lambda id: " << unhandledRequest.lambdaId;
         MPI_Send(unhandledRequest.lambdaId.c_str(), unhandledRequest.lambdaId.size(), MPI_CHAR, status.MPI_SOURCE, unhandledRequest.requestNumber, MPI_COMM_WORLD);
-      } else {
-        handlerStates[status.MPI_SOURCE].lambdasRunning--;
+      }
+      else
+      {
+        LOG_INFO << "No unhandled requests found, will reduce handler " << status.MPI_SOURCE << " lambdasRunning " << handlerStates[status.MPI_SOURCE - 1].lambdasRunning;
+        handlerStates[status.MPI_SOURCE - 1].lambdasRunning--;
       }
     }
 
@@ -28,7 +34,8 @@ void mpiHandler(int worldSize, std::vector<HandlerState> handlerStates, int &req
 
     auto request = pendingRequests.extract(status.MPI_TAG);
 
-    if (request.empty()) {
+    if (request.empty())
+    {
       LOG_WARN << "No pending request found for tag: " << status.MPI_TAG;
       return;
     }
@@ -37,8 +44,7 @@ void mpiHandler(int worldSize, std::vector<HandlerState> handlerStates, int &req
 
     std::string stringResponse(response, number_amount);
 
-    value.loop->queueInLoop([value, status, stringResponse, number_amount]() mutable {
-      value.callback(status, stringResponse);
-    });
+    value.loop->queueInLoop([value, status, stringResponse, number_amount]() mutable
+                            { value.callback(status, stringResponse); });
   }
 }

--- a/utils/restServer.hpp
+++ b/utils/restServer.hpp
@@ -8,80 +8,88 @@
 
 using namespace drogon;
 
-void restServer(int worldSize, std::vector<HandlerState> handlerStates, int &requestCounter, std::map<int, PendingRequest> &pendingRequests, std::queue<UnhandledRequest> &unhandledRequests) {
+void restServer(int worldSize, std::vector<HandlerState> &handlerStates, int &requestCounter, std::map<int, PendingRequest> &pendingRequests, std::queue<UnhandledRequest> &unhandledRequests)
+{
   app().registerHandler(
-    "/lambda/{lambda-id}",
-    [worldSize, &handlerStates, &requestCounter, &pendingRequests, &unhandledRequests](const HttpRequestPtr &request,
-        std::function<void(const HttpResponsePtr &)> &&callback,
-        const std::string &lambdaId)
-    {
-      int lambdaIdInt;
-      if (!convertToInt(lambdaId, &lambdaIdInt) && lambdaId.empty())
+      "/lambda/{lambda-id}",
+      [worldSize, &handlerStates, &requestCounter, &pendingRequests, &unhandledRequests](const HttpRequestPtr &request,
+                                                                                         std::function<void(const HttpResponsePtr &)> &&callback,
+                                                                                         const std::string &lambdaId)
       {
-        LOG_INFO << "Invalid request: missing lambda id " << lambdaId;
-        Json::Value json;
-        json["error"]="Missing lambda id";
-        auto resp = HttpResponse::newHttpJsonResponse(json);
-        resp->setStatusCode(k400BadRequest);
-        callback(resp);
-      } else {
-        int localRequestNumber;
-
-        requestCounterMutex.lock();
-        requestCounter++;
-        localRequestNumber = int(requestCounter);
-        requestCounterMutex.unlock();
-
-        LOG_INFO << "LambdaID: " << lambdaIdInt << " with request number: " << localRequestNumber;
-
-        stateMutex.lock();
-        auto availableHandler = getAvailableHandler(handlerStates);
-        if (availableHandler != 0) {
-          handlerStates[availableHandler - 1].lambdasRunning++;
-          LOG_INFO << "Lambdas running: " << handlerStates[availableHandler - 1].lambdasRunning;
-        }
-        stateMutex.unlock();
-
-        auto responseHandler = [&handlerStates, availableHandler, callback, &unhandledRequests](MPI_Status status, std::string response){
-          LOG_INFO << "Received from mpi " << status.MPI_TAG;
-
-          auto resp = HttpResponse::newHttpResponse();
-          resp->setStatusCode(k200OK);
-          resp->setBody(response);
-          resp->setContentTypeCode(CT_APPLICATION_JSON);
+        int lambdaIdInt;
+        if (!convertToInt(lambdaId, &lambdaIdInt) && lambdaId.empty())
+        {
+          LOG_INFO << "Invalid request: missing lambda id " << lambdaId;
+          Json::Value json;
+          json["error"] = "Missing lambda id";
+          auto resp = HttpResponse::newHttpJsonResponse(json);
+          resp->setStatusCode(k400BadRequest);
           callback(resp);
-          LOG_INFO << "Response sent for request: " << status.MPI_TAG;
-        };
-
-        pendingRequests[localRequestNumber] = { localRequestNumber, responseHandler, app().getIOLoop(app().getCurrentThreadIndex()) };
-
-        if (availableHandler == 0) {
-          LOG_WARN << "Request " << localRequestNumber << " will be enqued.";
-          {
-            std::lock_guard<std::mutex> lock(unhandledRequestsMutex);
-            unhandledRequests.push({ lambdaId, localRequestNumber });
-          }
-          return;
-        } else {
-          LOG_INFO << "Chosen node: " << availableHandler;
-          LOG_INFO << "MPI Send to start lambda with id: " << lambdaId;
-          MPI_Send(lambdaId.c_str(), lambdaId.size(), MPI_CHAR, availableHandler, localRequestNumber, MPI_COMM_WORLD);
         }
-      }
-    },
-    {Get});
+        else
+        {
+          int localRequestNumber;
+
+          requestCounterMutex.lock();
+          requestCounter++;
+          localRequestNumber = int(requestCounter);
+          requestCounterMutex.unlock();
+
+          LOG_INFO << "LambdaID: " << lambdaIdInt << " with request number: " << localRequestNumber;
+
+          stateMutex.lock();
+          auto availableHandler = getAvailableHandler(handlerStates);
+          if (availableHandler != 0)
+          {
+            handlerStates[availableHandler - 1].lambdasRunning++;
+            LOG_INFO << "Lambdas running: " << handlerStates[availableHandler - 1].lambdasRunning;
+          }
+          stateMutex.unlock();
+
+          auto responseHandler = [&handlerStates, availableHandler, callback, &unhandledRequests](MPI_Status status, std::string response)
+          {
+            LOG_INFO << "Received from mpi " << status.MPI_TAG;
+
+            auto resp = HttpResponse::newHttpResponse();
+            resp->setStatusCode(k200OK);
+            resp->setBody(response);
+            resp->setContentTypeCode(CT_APPLICATION_JSON);
+            callback(resp);
+            LOG_INFO << "Response sent for request: " << status.MPI_TAG;
+          };
+
+          pendingRequests[localRequestNumber] = {localRequestNumber, responseHandler, app().getIOLoop(app().getCurrentThreadIndex())};
+
+          if (availableHandler == 0)
+          {
+            LOG_WARN << "Request " << localRequestNumber << " will be enqued.";
+            {
+              std::lock_guard<std::mutex> lock(unhandledRequestsMutex);
+              unhandledRequests.push({lambdaId, localRequestNumber});
+            }
+            return;
+          }
+          else
+          {
+            LOG_INFO << "Chosen node: " << availableHandler;
+            LOG_INFO << "MPI Send to start lambda with id: " << lambdaId;
+            MPI_Send(lambdaId.c_str(), lambdaId.size(), MPI_CHAR, availableHandler, localRequestNumber, MPI_COMM_WORLD);
+          }
+        }
+      },
+      {Get});
 
   LOG_INFO << "Server running on http://127.0.0.1:8848";
   // Set the number of threads to 0 to use as many threads as available CPU cores
-  //app().setThreadNum(0);
+  // app().setThreadNum(0);
   app().addListener("127.0.0.1", 8848);
   app().setIntSignalHandler(
-    []()
-    {
-      LOG_INFO << "Server is going to exit.";
-      MPI_Finalize();
-      app().quit();
-    });
+      []()
+      {
+        LOG_INFO << "Server is going to exit.";
+        MPI_Finalize();
+        app().quit();
+      });
 
   app().run();
 }


### PR DESCRIPTION
## Description
I forgot the `&` which broke things. The `mpiHandler` thread was using a copy of the initial value.